### PR TITLE
feat: --help/-h フラグでヘルプを表示

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -227,8 +227,9 @@ gitpp clone -c /mnt/ssd/gitpp.yaml -r /mnt/ssd/repos
 # クワイエットモード（TUIなし — サマリーは stdout、進捗は stderr）
 gitpp pull -q
 
-# バージョン確認
-gitpp --version
+# ヘルプ / バージョン確認
+gitpp --help            # or: gitpp -h
+gitpp --version         # or: gitpp -V
 
 # インタラクティブモード（タブ補完付き）
 gitpp

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ gitpp clone -c /mnt/ssd/gitpp.yaml -r /mnt/ssd/repos
 # Quiet mode (no TUI — summary to stdout, progress to stderr)
 gitpp pull -q
 
-# Version
+# Help / Version
+gitpp --help            # or: gitpp -h
 gitpp --version         # or: gitpp -V
 
 # Interactive mode with tab completion

--- a/src/main.rs
+++ b/src/main.rs
@@ -541,7 +541,10 @@ fn show_help() {
     println!(
         "  \x1b[1;33m-q\x1b[0m, \x1b[1;33m--quiet\x1b[0m              No TUI; progress on stderr, summary on stdout"
     );
-    println!("  \x1b[1;33m-V\x1b[0m, \x1b[1;33m--version\x1b[0m            Show version\n");
+    println!("  \x1b[1;33m-V\x1b[0m, \x1b[1;33m--version\x1b[0m            Show version");
+    println!(
+        "  \x1b[1;33m-h\x1b[0m, \x1b[1;33m--help\x1b[0m               Show this help message\n"
+    );
     println!("\x1b[1;36mShortcuts:\x1b[0m");
     println!("  clo, cl  → clone      st → status");
     println!("  pul, pl  → pull       di → diff");

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,11 @@ fn main() {
         return;
     }
 
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        show_help();
+        return;
+    }
+
     let global_opts = parse_global_options(&args);
 
     let setting = match setting_util::load(global_opts.config_path.as_deref()) {


### PR DESCRIPTION
## 関連 Issue
closes #22

## 変更内容
- `--version` チェックの直後に `--help` / `-h` チェックを追加
- gitpp.yaml 読み込み前に処理するため、設定ファイルがなくてもヘルプが表示される
- README.md / README.ja.md にヘルプフラグの例を追記