### PR TITLE
fix: #19 PowerShellでキーリリースイベント二重処理を修正

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,5 @@
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -215,14 +215,16 @@ impl TuiApp {
                 terminal.draw(|f| self.ui(f))?;
                 if event::poll(Duration::from_secs(3))? {
                     if let Event::Key(key) = event::read()? {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => break,
-                            _ => {
-                                // User interacted, switch to browse mode
-                                self.auto_exit_hint = false;
-                                self.handle_key(key.code);
-                                self.browse_mode(terminal)?;
-                                break;
+                        if key.kind == KeyEventKind::Press {
+                            match key.code {
+                                KeyCode::Char('q') | KeyCode::Esc => break,
+                                _ => {
+                                    // User interacted, switch to browse mode
+                                    self.auto_exit_hint = false;
+                                    self.handle_key(key.code);
+                                    self.browse_mode(terminal)?;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -232,10 +234,12 @@ impl TuiApp {
 
             if event::poll(Duration::from_millis(100))? {
                 if let Event::Key(key) = event::read()? {
-                    match key.code {
-                        KeyCode::Char('q') => break,
-                        KeyCode::Esc if !self.show_detail => break,
-                        _ => self.handle_key(key.code),
+                    if key.kind == KeyEventKind::Press {
+                        match key.code {
+                            KeyCode::Char('q') => break,
+                            KeyCode::Esc if !self.show_detail => break,
+                            _ => self.handle_key(key.code),
+                        }
                     }
                 }
             }
@@ -250,10 +254,12 @@ impl TuiApp {
 
             if event::poll(Duration::from_millis(100))? {
                 if let Event::Key(key) = event::read()? {
-                    match key.code {
-                        KeyCode::Char('q') => break,
-                        KeyCode::Esc if !self.show_detail => break,
-                        _ => self.handle_key(key.code),
+                    if key.kind == KeyEventKind::Press {
+                        match key.code {
+                            KeyCode::Char('q') => break,
+                            KeyCode::Esc if !self.show_detail => break,
+                            _ => self.handle_key(key.code),
+                        }
                     }
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -213,34 +213,26 @@ impl TuiApp {
 
             if all_done {
                 terminal.draw(|f| self.ui(f))?;
-                if event::poll(Duration::from_secs(3))? {
-                    if let Event::Key(key) = event::read()? {
-                        if key.kind == KeyEventKind::Press {
-                            match key.code {
-                                KeyCode::Char('q') | KeyCode::Esc => break,
-                                _ => {
-                                    // User interacted, switch to browse mode
-                                    self.auto_exit_hint = false;
-                                    self.handle_key(key.code);
-                                    self.browse_mode(terminal)?;
-                                    break;
-                                }
-                            }
+                if let Some(code) = Self::poll_key_press(Duration::from_secs(3))? {
+                    match code {
+                        KeyCode::Char('q') | KeyCode::Esc => break,
+                        _ => {
+                            // User interacted, switch to browse mode
+                            self.auto_exit_hint = false;
+                            self.handle_key(code);
+                            self.browse_mode(terminal)?;
+                            break;
                         }
                     }
                 }
                 break;
             }
 
-            if event::poll(Duration::from_millis(100))? {
-                if let Event::Key(key) = event::read()? {
-                    if key.kind == KeyEventKind::Press {
-                        match key.code {
-                            KeyCode::Char('q') => break,
-                            KeyCode::Esc if !self.show_detail => break,
-                            _ => self.handle_key(key.code),
-                        }
-                    }
+            if let Some(code) = Self::poll_key_press(Duration::from_millis(100))? {
+                match code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Esc if !self.show_detail => break,
+                    _ => self.handle_key(code),
                 }
             }
         }
@@ -252,19 +244,28 @@ impl TuiApp {
         loop {
             terminal.draw(|f| self.ui(f))?;
 
-            if event::poll(Duration::from_millis(100))? {
-                if let Event::Key(key) = event::read()? {
-                    if key.kind == KeyEventKind::Press {
-                        match key.code {
-                            KeyCode::Char('q') => break,
-                            KeyCode::Esc if !self.show_detail => break,
-                            _ => self.handle_key(key.code),
-                        }
-                    }
+            if let Some(code) = Self::poll_key_press(Duration::from_millis(100))? {
+                match code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Esc if !self.show_detail => break,
+                    _ => self.handle_key(code),
                 }
             }
         }
         Ok(())
+    }
+
+    /// Poll for a key press/repeat event, ignoring release events.
+    /// Returns `Some(KeyCode)` on press/repeat, `None` on timeout or non-key event.
+    fn poll_key_press(timeout: Duration) -> io::Result<Option<KeyCode>> {
+        if event::poll(timeout)? {
+            if let Event::Key(key) = event::read()? {
+                if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                    return Ok(Some(key.code));
+                }
+            }
+        }
+        Ok(None)
     }
 
     fn handle_key(&mut self, key: KeyCode) {


### PR DESCRIPTION
## 関連 Issue
closes #19

## 変更内容
crossterm 0.28はWindows PowerShellで`KeyRelease`/`KeyRepeat`イベントも発火する。
`tui.rs`の全イベント処理箇所（3箇所）で`KeyEventKind::Press`のみを処理するようフィルタを追加。

### 原因
- `Event::Key(key)`マッチで`key.kind`をチェックしていなかった
- PowerShellではEnter押下時にPress→Releaseの2イベントが発生
- `show_detail`のトグルが即座に打ち消され「一瞬表示→消える」現象が発生

### 修正
- `run_app`メインループ（L234）
- `run_app` all_done後（L217）
- `browse_mode`（L254）

の3箇所に`if key.kind == KeyEventKind::Press`ガードを追加。