### PR TITLE
fix: TUI終了時のマウスイベント漏れを修正

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -178,9 +178,9 @@ impl TuiApp {
 
         let res = self.run_app(&mut terminal);
 
-        // Drain pending mouse/resize events so stray SGR bytes
+        // Drain pending terminal events so stray SGR mouse bytes
         // don't leak into the shell prompt after TUI exit.
-        while event::poll(Duration::from_millis(0))? {
+        while event::poll(Duration::ZERO).unwrap_or(false) {
             let _ = event::read();
         }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -178,6 +178,12 @@ impl TuiApp {
 
         let res = self.run_app(&mut terminal);
 
+        // Drain pending mouse/resize events so stray SGR bytes
+        // don't leak into the shell prompt after TUI exit.
+        while event::poll(Duration::from_millis(0))? {
+            let _ = event::read();
+        }
+
         disable_raw_mode()?;
         execute!(
             terminal.backend_mut(),


### PR DESCRIPTION
## 関連 Issue
closes #25

## 変更内容
- `tui.rs` の `run()` で `disable_raw_mode()` の前にイベントキューを排水するループを追加
- TUI終了時にバッファに残ったSGRマウストラッキングのバイト列がシェルの stdin に流れ込むのを防止

## 変更ファイル
- `src/tui.rs`: drain ループ追加（+6行）